### PR TITLE
Adding image optimization tools to people/tylersticka module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -80,5 +80,7 @@ github "firefox"
 
 github "atom"
 
+github "imageoptim"
+
 # Requirements for future project-specific setups.
 # github "postgresql", "3.0.1"

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -74,6 +74,11 @@ GITHUBTARBALL
     hub (1.3.0)
 
 GITHUBTARBALL
+  remote: boxen/puppet-imageoptim
+  specs:
+    imageoptim (0.0.2)
+
+GITHUBTARBALL
   remote: boxen/puppet-iterm2
   specs:
     iterm2 (1.2.2)
@@ -165,9 +170,9 @@ GITHUBTARBALL
 
 DEPENDENCIES
   atom (>= 0)
-  chrome (>= 0)
   boxen (= 3.10.1)
   brewcask (= 0.0.4)
+  chrome (>= 0)
   dnsmasq (= 2.0.1)
   dropbox (>= 0)
   firefox (>= 0)
@@ -179,6 +184,7 @@ DEPENDENCIES
   heroku (>= 0)
   homebrew (= 1.11.2)
   hub (= 1.3.0)
+  imageoptim (>= 0)
   inifile (= 1.1.1)
   iterm2 (>= 0)
   java (= 1.8.0)
@@ -197,3 +203,4 @@ DEPENDENCIES
   virtualbox (= 1.0.13)
   wget (= 1.0.1)
   xquartz (= 1.2.1)
+

--- a/modules/imagealpha/manifests/init.pp
+++ b/modules/imagealpha/manifests/init.pp
@@ -1,0 +1,11 @@
+# Install ImageAlpha
+#
+# To use:
+#   include imagealpha
+class imagealpha {
+  package { 'ImageAlpha':
+    provider => 'compressed_app',
+    source   => 'http://pngmini.com/ImageAlpha1.3.5.tar.bz2',
+    flavor   => 'tbz'
+  }
+}

--- a/modules/people/manifests/tylersticka.pp
+++ b/modules/people/manifests/tylersticka.pp
@@ -1,3 +1,11 @@
 class people::tylersticka {
-  notice('Hi, Tyler! Happy designing...')
+  # npm
+  nodejs::module { 'svgo for 0.10': module => 'svgo', node_version => 'v0.10' }
+
+  # modules
+  include imageoptim
+  include imagealpha
+
+  # hello
+  notice('Hi, Tyler! Happy designing 😄')
 }


### PR DESCRIPTION
My first Boxen PR! Exciting! :smile: 

After @lyzadanger's meeting earlier, I wanted to put my new knowledge to the test and attempt to solve my ask for #6 all by my lonesome.

The three tools I wanted to install are...
- [ImageOptim](https://imageoptim.com/), which was just a matter of including [boxen/puppet-imageoptim](https://github.com/boxen/puppet-imageoptim)
- [ImageAlpha](http://pngmini.com/), in which I mimicked the manifest of `puppet-imageoptim` (they are by the same author, so it worked like a charm)
- [svgo](https://github.com/svg/svgo) via `npm` (because the GUI is only easily available as `7z` and I tend to use it infrequently anyway)

(I also frivolously added a unicode emoji to my personal notice because the OS X Terminal totally supports it and it makes me happy.)

If we were to make a "design" team module, I have a feeling these modules would be a good fit for it. But I wanted to start small at first and wait for someone more knowledgable than I to check my work.
