### PR TITLE
Factoring out of core

### DIFF
--- a/modules/cloudfour/manifests/init.pp
+++ b/modules/cloudfour/manifests/init.pp
@@ -34,14 +34,8 @@ class cloudfour {
   include atom
 
   # dev
-  include heroku
+  #include heroku
   include virtualbox
-
-  # https://github.com/boxen/puppet-heroku
-  # goes with heroku
-  heroku::plugin { 'accounts':
-    source => 'ddollar/heroku-accounts'
-  }
 
   # Everyone gets Sass
   ruby_gem { 'SASS for all rubies':

--- a/modules/people/manifests/lyzadanger.pp
+++ b/modules/people/manifests/lyzadanger.pp
@@ -1,4 +1,5 @@
 class people::lyzadanger {
+  include teams::dev
   include mamppro
   notice("Hi, future Lyza, from past Lyza")
 }

--- a/modules/teams/manifests/dev.pp
+++ b/modules/teams/manifests/dev.pp
@@ -1,0 +1,12 @@
+class teams::dev {
+  # Things the dev team needs that may be
+  # extraneous for other folkx
+  notice('Hi from Team dev!')
+  include heroku
+
+  # https://github.com/boxen/puppet-heroku
+  # goes with heroku
+  heroku::plugin { 'accounts':
+    source => 'ddollar/heroku-accounts'
+  }
+}


### PR DESCRIPTION
This PR marks us moving away from kitchen-sinking the `cloudfour` module and moving toward teams and other modules. Includes the first team module, `dev`, and its inclusion in `lyzadanger`'s personal module.
