### PR TITLE
Making cloudfour potions

### DIFF
--- a/modules/cloudfour_potions/manifests/atom.pp
+++ b/modules/cloudfour_potions/manifests/atom.pp
@@ -1,0 +1,4 @@
+class cloudfour_potions::atom {
+  include atom
+  atom::package { 'editorconfig': }
+}

--- a/modules/cloudfour_potions/manifests/init.pp
+++ b/modules/cloudfour_potions/manifests/init.pp
@@ -1,0 +1,3 @@
+class cloudfour_potions {
+  
+}

--- a/modules/cloudfour_potions/manifests/sublime_text.pp
+++ b/modules/cloudfour_potions/manifests/sublime_text.pp
@@ -1,0 +1,6 @@
+class cloudfour_potions::sublime_text {
+  include sublime_text
+  sublime_text::package { 'editorconfig':
+    source => 'sindresorhus/editorconfig-sublime'
+  }
+}

--- a/modules/people/manifests/lyzadanger.pp
+++ b/modules/people/manifests/lyzadanger.pp
@@ -1,7 +1,7 @@
 class people::lyzadanger {
-  include atom
-  include iterm2
-  
+  include iterm2::dev
+
   include mamppro
+  include cloudfour_potions::atom
   notice("Hi, future Lyza, from past Lyza")
 }

--- a/modules/people/manifests/template_for_people_modules.pp
+++ b/modules/people/manifests/template_for_people_modules.pp
@@ -3,9 +3,14 @@
 # people::[your-github-username]
 class people::template_for_people_modules {
   ## Uncomment any of the following for the puppet-* module
-  # include atom
-  # include sublime_text
-  # include iterm2
+  #
+  # include iterm2::dev
+  # OR
+  # include iterm2::stable
+
+  ## Uncomment for our own "potions"
+  # include cloudfour_potions::atom
+  # include cloudfour_potions::sublime_text
 
   ## Uncomment for our own modules
   #


### PR DESCRIPTION
This PR flavors existing puppet modules with a cloudfour wrapper. In this case, ensuring the install of editorconfig packages for editors.

This right now assumes Sublime 3, but we can use 2 if that ends up being more sane.

Atom variant is tested in my own personal module. I have _not_ tested Sublime.
