### PR TITLE
LICEcap module

### DIFF
--- a/modules/licecap/manifests/init.pp
+++ b/modules/licecap/manifests/init.pp
@@ -1,0 +1,14 @@
+# Public: Install licecap.app into /Applications.
+#
+# It's a tool for taking a capture of your desktop and generating a .GIF
+# http://www.cockos.com/licecap/
+#
+# Examples
+#
+#   include licecap
+class licecap {
+  package { 'LICEcap':
+    provider => 'appdmg_eula',
+    source   => 'http://www.cockos.com/licecap/licecap125.dmg'
+  }
+}

--- a/modules/people/manifests/tylersticka.pp
+++ b/modules/people/manifests/tylersticka.pp
@@ -5,6 +5,7 @@ class people::tylersticka {
   # modules
   include imageoptim
   include imagealpha
+  include licecap
 
   # hello
   notice('Hi, Tyler! Happy designing 😄')


### PR DESCRIPTION
Stealing (but bumping the version of) the [LICECap module here](https://github.com/alphagov/gds-boxen/tree/master/modules/licecap) (and adding it to my own module).

This _might_ be something un-opinionated enough to install for everyone... I feel like _everyone_ (internally and externally) has asked me about this app at one point or another.
