### PR TITLE
JSCS: Require curly braces for most blocks

### DIFF
--- a/modules/cloudfour_potions/files/dotfiles/jscsrc
+++ b/modules/cloudfour_potions/files/dotfiles/jscsrc
@@ -9,6 +9,7 @@
  {
    "disallowMixedSpacesAndTabs": true,
    "requireCamelCaseOrUpperCaseIdentifiers": true,
+   "requireCurlyBraces": [ "if", "else", "for", "while", "do", "try", "catch"],
    "requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!==", ">", "<", ">=", "<="],
    "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
    "requireSpaceAfterLineComment": true,


### PR DESCRIPTION
Discussion welcome!

I prefer to enforce the convention of curly braces in most blocks because of inadvertent errors otherwise. Some like to be able to do one-line `if`s without braces but I feel that it opens the door to mistakes later.

Thoughts?
