### PR TITLE
Update the editorconfig file to add the * selector.

### DIFF
--- a/modules/cloudfour_potions/files/dotfiles/editorconfig
+++ b/modules/cloudfour_potions/files/dotfiles/editorconfig
@@ -1,3 +1,4 @@
+[*]
 indent_style = space
 indent_size = 2
 charset = utf-8


### PR DESCRIPTION
Sublime Text needs a bit more help to understand the .editorconfig file. By adding the [*], ST will happily read and apply the .editorconfig settings to all new files created thereafter. Also to note, the http://editorconfig.org/ example actually uses the [*] selector as well. Perhaps being more explicit will be better overall.
