### PR TITLE
Remove `globalstrict` from .jshintrc

### DIFF
--- a/modules/cloudfour_potions/files/dotfiles/jshintrc
+++ b/modules/cloudfour_potions/files/dotfiles/jshintrc
@@ -6,7 +6,6 @@
         "process",
         "$"
     ],
-    "globalstrict" : true,
     "camelcase"    : true,
     "eqeqeq"       : true,
     "nonew"        : true


### PR DESCRIPTION
Removing `globalstrict` option from our shared `jshintrc` so we don't have to litter our source with `use strict` statements.
