### PR TITLE
Update ruby versions

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -8,16 +8,14 @@
 # heart's content.
 
 # See https://github.com/boxen/puppet-ruby for docs
-ruby::global::version: "2.1.0"
+ruby::global::version: 2.2.3
+ruby::build::ensure: "v20151024"
 ruby::rbenv_plugins:
   rbenv-vars:
     ensure: v1.0.0
     source: sstephenson/rbenv-vars
-  ruby-build:
-    ensure: v20131225.1
-    source: sstephenson/ruby-build
 ruby::version::alias:
-  2.0.0: 2.0.0-p353
+  2.0.0: 2.0.0-p647
 
 # Based on what I see , you cannot control global
 # nodejs version from hiera

--- a/modules/cloudfour/manifests/init.pp
+++ b/modules/cloudfour/manifests/init.pp
@@ -47,7 +47,7 @@ class cloudfour {
   # See https://github.com/cloudfour/cloudfour-boxen/issues/10
   # class { 'nodejs::global': version => '0.12' }
   # See https://github.com/cloudfour/cloudfour-boxen/issues/9
-  class { 'ruby::global': version => '2.1.0' }
+  class { 'ruby::global': version => '2.2.3' }
 
   # Symlink to boxen script from Applications dir for
   # those who like to double-click on things


### PR DESCRIPTION
Pulling in hiera defaults from upstream. Still unable
to set system ruby from hiera so have reopened #9
but now system ruby is at 2.2.3 instead of 2.1.0.

This is wrapping up some stuff I ran into the other day with @mrgerardorodriguez ...

It won't fix the [odd `bundler` problems with El Capitan](https://github.com/boxen/our-boxen/issues/794) but it should keep us from having really outdated ruby versions.

@mrgerardorodriguez Please check out this branch from within your `boxen` repo (`/opt/boxen/repo`) and then run the `boxen` command. Let me know if you run into any issues. (Don't forget to check out `master` again afterward!).
