### PR TITLE
Update node versions

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -17,6 +17,7 @@ ruby::rbenv_plugins:
 ruby::version::alias:
   2.0.0: 2.0.0-p647
 
+nodejs::build::ensure: "3c0dce2b91d1e1aca285bef2d52290bc874d5938"
 # Based on what I see , you cannot control global
 # nodejs version from hiera
 # see https://github.com/boxen/puppet-nodejs/issues/28

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -67,7 +67,10 @@ node default {
   nodejs::version { '0.10': }
   nodejs::version { '0.12': }
   # This differs from upstream, but it's practically 2016, guys
+  # Global is set in cloudfour module
   nodejs::version { '4.0.0': }
+  nodejs::version { '4.2.2': }
+  nodejs::version { '5.2.0': }
 
   # default ruby versions
   ruby::version { '1.9.3': }


### PR DESCRIPTION
This PR does a few things. It needs a bit of background explainer here.

node versions are managed via [`boxen/puppet-nodejs`](https://github.com/boxen/puppet-nodejs). Sort of. That module depends on [nodenv](https://github.com/OiNutter/nodenv) which in turn uses [node-build](https://github.com/OiNutter/node-build) to provide definitions of what versions of node are install-able.

`puppet-nodejs` references an out-of-date version of `node-build`, only providing node versions through `4.0.0`. To get newer version definitions, you'll see I've added a new line to `hiera/common.yaml` pointing at the specific hash I want to use for `node-build` (this hash represents the most recent commit on their `master`, FWIW). This gets us a newer version of `node-build` than boxen's `nodejs` module would give us. 

Now I can install a few more node versions (`4.2.2`, `5.2.0`) for all of us. But I'm leaving system node at `4.0.0` until we get past a few hiccups we're having.

Useful tips:

* `nodenv versions` to see all versions of node you have, and what is currently the global version
* `node-build --definitions` to see all available versions of node you can install
* Preferred method of installing new versions is to add to `boxen` but `nodenv install <version>` will also do in a pinch. You can install any version of node listed by the previous `node-build` command.

Feels like some of this should be documented somewhere. Anyone have any ideas?

/cc @mrgerardorodriguez @tylersticka @erikjung 